### PR TITLE
feat: add matcher option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,47 @@ export default defineConfig({
 })
 ```
 
+#### matcher
+
+- Path Syntax: `./[srcDir]/[filename].[js,ts]`
+
+The `matcher` basically parses all output paths and replaces `filename` with the user's custom value.
+
+```js
+export default defineConfig({
+  exports: {
+    matcher: {
+      types: 'dts', // renames all 'types' inputs to 'dts.ts'
+      import: 'esm', // renames all 'import' inputs to 'esm.{js,ts}'
+      require: 'cjs', // renames all 'require' inputs to 'cjs.{js,ts}'
+    },
+  },
+})
+```
+
+So now all input paths, including recursive ones, will be accordingly matched.
+
+```js
+// package.json
+{
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts", // matches the input './src/types/dts.ts'
+      "import": "./dist/index.mjs", // matches the input './src/esm.{js,ts}'
+      "require": "./dist/index.cjs", // matches the input './src/cjs.{js,ts}'
+    },
+    "./path": {
+      "types": "./dist/types/path/index.d.ts", // matches the input './src/types/path/dts.ts'
+      "import": "./dist/path/index.mjs", // matches the input './src/path/esm.{js,ts}'
+      "require": "./dist/path/index.cjs", // matches the input './src/path/cjs.{js,ts}'
+    },
+    // ...
+  },
+}
+```
+
+#### exclude
+
 It is possible to exclude certain paths from the auto-build mode.
 
 The `exclude` option accepts an array of strings, which are essentially paths, or an array of objects that can individually control path's _types_, _import_ or _require_ options.
@@ -234,6 +275,35 @@ export default defineConfig({
   },
 })
 ```
+
+#### matcher
+
+- Path Syntax: `./[srcDir]/[filename].[js,ts]`
+
+The `matcher` basically parses all output paths and replaces `filename` with the user's custom value.
+
+```js
+export default defineConfig({
+  bin: {
+    matcher: 'cli', // renames all inputs to 'cli.{js,ts}'
+  },
+})
+```
+
+So now all input paths, including recursive ones, will be accordingly matched.
+
+```js
+// package.json
+{
+  "bin": {
+    "command": "./dist/cli/index.mjs", // matches the input './src/cli/cli.{js,ts}'
+    "command2": "./dist/cli/dir/index.cjs", // matches the input './src/cli/dir/cli.{js,ts}'
+    // ...
+  }
+}
+```
+
+#### exclude
 
 It is possible to exclude certain paths from the auto-build mode.
 

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -7,11 +7,18 @@ import type { Options as DtsOptions } from 'rollup-plugin-dts'
 
 type Externals = (string | RegExp)[]
 
-type ExcludeExportsPath = {
+type ExportsExclude = {
   path: string
   types?: true
   import?: true
   require?: true
+}
+
+type ExportsMatcher = {
+  default?: string
+  types?: string
+  import?: string
+  require?: string
 }
 
 export interface Plugins {
@@ -28,7 +35,8 @@ export interface ExportsOptions extends Plugins {
   logFilter?: string[]
   minify?: boolean
   tsconfig?: string
-  exclude?: (string | ExcludeExportsPath)[]
+  exclude?: (string | ExportsExclude)[]
+  matcher?: ExportsMatcher
 }
 
 export interface BinOptions extends Omit<Plugins, 'dts'> {
@@ -38,6 +46,7 @@ export interface BinOptions extends Omit<Plugins, 'dts'> {
   minify?: boolean
   tsconfig?: string
   exclude?: string[]
+  matcher?: string
 }
 
 export interface EntriesOptions extends Plugins {

--- a/src/utils/get-input-path.ts
+++ b/src/utils/get-input-path.ts
@@ -1,11 +1,26 @@
 import { parse } from 'node:path'
 import { exists } from 'utills/node'
 
-export async function getInputPath(srcDir: string, output: string) {
+export async function getInputPath(
+  srcDir: string,
+  output: string,
+  matcher?: string,
+) {
   const outputDir = output.split('/')[1]
-  const inputDir = output.replace(outputDir, srcDir)
-  const inputJs = inputDir.replace(parse(inputDir).ext, '.js')
-  const inputTs = inputDir.replace(parse(inputDir).ext, '.ts')
+  const outputPath = output.replace(outputDir, srcDir)
+  let inputJs = ''
+  let inputTs = ''
+
+  if (!matcher) {
+    const outputExt = parse(outputPath).ext
+    inputJs = outputPath.replace(outputExt, '.js')
+    inputTs = outputPath.replace(outputExt, '.ts')
+  } else {
+    const outputBase = parse(outputPath).base
+    inputJs = outputPath.replace(outputBase, `${matcher}.js`)
+    inputTs = outputPath.replace(outputBase, `${matcher}.ts`)
+  }
+
   const fileJs = await exists(inputJs)
 
   return fileJs ? inputJs : inputTs


### PR DESCRIPTION

## Type of Change

- [x] New feature
- [x] Documentation

## Request Description

Adds new `matcher` options for `exports` and `bin` _auto-build_ modes.


### exports matcher

- Path Syntax: `./[srcDir]/[filename].[js,ts]`

The `matcher` basically parses all output paths and replaces `filename` with the user's custom value.

```js
export default defineConfig({
  exports: {
    matcher: {
      types: 'dts', // renames all 'types' inputs to 'dts.ts'
      import: 'esm', // renames all 'import' inputs to 'esm.{js,ts}'
      require: 'cjs', // renames all 'require' inputs to 'cjs.{js,ts}'
    },
  },
})
```

So now all input paths, including recursive ones, will be accordingly matched.

```js
// package.json
{
  "exports": {
    ".": {
      "types": "./dist/types/index.d.ts", // matches the input './src/types/dts.ts'
      "import": "./dist/index.mjs", // matches the input './src/esm.{js,ts}'
      "require": "./dist/index.cjs", // matches the input './src/cjs.{js,ts}'
    },
    "./path": {
      "types": "./dist/types/path/index.d.ts", // matches the input './src/types/path/dts.ts'
      "import": "./dist/path/index.mjs", // matches the input './src/path/esm.{js,ts}'
      "require": "./dist/path/index.cjs", // matches the input './src/path/cjs.{js,ts}'
    },
    // ...
  },
}
```

---

### bin matcher

- Path Syntax: `./[srcDir]/[filename].[js,ts]`

The `matcher` basically parses all output paths and replaces `filename` with the user's custom value.

```js
export default defineConfig({
  bin: {
    matcher: 'cli', // renames all inputs to 'cli.{js,ts}'
  },
})
```

So now all input paths, including recursive ones, will be accordingly matched.

```js
// package.json
{
  "bin": {
    "command": "./dist/cli/index.mjs", // matches the input './src/cli/cli.{js,ts}'
    "command2": "./dist/cli/dir/index.cjs", // matches the input './src/cli/dir/cli.{js,ts}'
    // ...
  }
}
```

