### PR TITLE
feat: add plugins options

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,22 @@ So now all input paths, including recursive ones, will be accordingly matched.
 }
 ```
 
+#### plugins
+
+Default plugin system is quite powerful, but if needed, it can be easily extended via the `plugins` option.
+
+```js
+export default defineConfig({
+  exports: {
+    plugins: [
+      plugin1(),
+      plugin2(),
+      // ...
+    ],
+  },
+})
+```
+
 #### exclude
 
 It is possible to exclude certain paths from the auto-build mode.
@@ -303,6 +319,22 @@ So now all input paths, including recursive ones, will be accordingly matched.
 }
 ```
 
+#### plugins
+
+Default plugin system is quite powerful, but if needed, it can be easily extended via the `plugins` option.
+
+```js
+export default defineConfig({
+  bin: {
+    plugins: [
+      plugin1(),
+      plugin2(),
+      // ...
+    ],
+  },
+})
+```
+
 #### exclude
 
 It is possible to exclude certain paths from the auto-build mode.
@@ -358,15 +390,33 @@ export default defineConfig({
 To use fully custom-build mode, disable auto-build modes and specify the entries as needed:
 
 ```js
-// rolli.config.js
-
 export default defineConfig({
   // auto-build modes will be ignored
   exports: false,
   bin: false,
-  // only custom entries will be bundled
+  // only custom entries will be compiled
   entries: [
     // ...
+  ],
+})
+```
+
+#### plugins
+
+Default plugin system is quite powerful, but if needed, it can be easily extended via the `plugins` option.
+
+```js
+export default defineConfig({
+  entries: [
+    {
+      input: './src/index.ts',
+      output: './dist/index.mjs',
+      plugins: [
+        plugin1(),
+        plugin2(),
+        // ...
+      ],
+    },
   ],
 })
 ```

--- a/src/cli/builder.ts
+++ b/src/cli/builder.ts
@@ -139,6 +139,8 @@ export async function createBuilder(
       exportsPlugins.unshift(resolvePlugin(resolveOptions))
     }
 
+    if (exports.plugins) exportsPlugins.push(...exports.plugins)
+
     const exportsBuilder: InputOptions = {
       external: exports.externals,
       plugins: exportsPlugins,
@@ -342,6 +344,8 @@ export async function createBuilder(
       binPlugins.unshift(resolvePlugin(resolveOptions))
     }
 
+    if (bin.plugins) binPlugins.push(...bin.plugins)
+
     const binBuilder: InputOptions = {
       external: bin.externals,
       plugins: binPlugins,
@@ -460,6 +464,8 @@ export async function createBuilder(
           : undefined
         entryPlugins.unshift(resolvePlugin(resolveOptions))
       }
+
+      if (entry.plugins) entryPlugins.push(...entry.plugins)
 
       const { input, output, banner, footer } = entry
       const outputLogs: OutputLogs[] = []

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,4 +1,4 @@
-import type { OutputOptions } from 'rollup'
+import type { OutputOptions, Plugin } from 'rollup'
 import type { RollupReplaceOptions } from '@rollup/plugin-replace'
 import type { RollupJsonOptions } from '@rollup/plugin-json'
 import type { RollupNodeResolveOptions } from '@rollup/plugin-node-resolve'
@@ -37,6 +37,7 @@ export interface ExportsOptions extends Plugins {
   tsconfig?: string
   exclude?: (string | ExportsExclude)[]
   matcher?: ExportsMatcher
+  plugins?: Plugin[]
 }
 
 export interface BinOptions extends Omit<Plugins, 'dts'> {
@@ -47,6 +48,7 @@ export interface BinOptions extends Omit<Plugins, 'dts'> {
   tsconfig?: string
   exclude?: string[]
   matcher?: string
+  plugins?: Plugin[]
 }
 
 export interface EntriesOptions extends Plugins {
@@ -59,6 +61,7 @@ export interface EntriesOptions extends Plugins {
   footer?: OutputOptions['footer']
   minify?: boolean
   tsconfig?: string
+  plugins?: Plugin[]
 }
 
 export interface RolliOptions {


### PR DESCRIPTION

## Type of Change


- [x] New feature
- [x] Documentation

## Request Description

Adds new `plugins` options.

Default plugin system is quite powerful, but if needed, it can be easily extended via the `plugins` option.

### exports plugins

```js
export default defineConfig({
  exports: {
    plugins: [
      plugin1(),
      plugin2(),
      // ...
    ],
  },
})
```

### bin plugins

```js
export default defineConfig({
  bin: {
    plugins: [
      plugin1(),
      plugin2(),
      // ...
    ],
  },
})
```

### entries plugins

```js
export default defineConfig({
  entries: [
    {
      input: './src/index.ts',
      output: './dist/index.mjs',
      plugins: [
        plugin1(),
        plugin2(),
        // ...
      ],
    },
  ],
})
```