### PR TITLE
feat: extend plugins option

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ So now all input paths, including recursive ones, will be accordingly matched.
 
 Default plugin system is quite powerful, but if needed, it can be easily extended via the `plugins` option.
 
+The `plugins` option accepts an array of plugins.
+
 ```js
 export default defineConfig({
   exports: {
@@ -229,6 +231,19 @@ export default defineConfig({
       plugin2(),
       // ...
     ],
+  },
+})
+```
+
+Or it can be an object that explicitly defines when user plugins will run, before or after the default ones.
+
+```js
+export default defineConfig({
+  exports: {
+    plugins: {
+      start: [plugin1()], // runs 'before' the default plugins
+      end: [plugin2()], // runs 'after' the default plugins
+    },
   },
 })
 ```
@@ -323,6 +338,8 @@ So now all input paths, including recursive ones, will be accordingly matched.
 
 Default plugin system is quite powerful, but if needed, it can be easily extended via the `plugins` option.
 
+The `plugins` option accepts an array of plugins.
+
 ```js
 export default defineConfig({
   bin: {
@@ -331,6 +348,19 @@ export default defineConfig({
       plugin2(),
       // ...
     ],
+  },
+})
+```
+
+Or it can be an object that explicitly defines when user plugins will run, before or after the default ones.
+
+```js
+export default defineConfig({
+  bin: {
+    plugins: {
+      start: [plugin1()], // runs 'before' the default plugins
+      end: [plugin2()], // runs 'after' the default plugins
+    },
   },
 })
 ```
@@ -405,6 +435,8 @@ export default defineConfig({
 
 Default plugin system is quite powerful, but if needed, it can be easily extended via the `plugins` option.
 
+The `plugins` option accepts an array of plugins.
+
 ```js
 export default defineConfig({
   entries: [
@@ -416,6 +448,23 @@ export default defineConfig({
         plugin2(),
         // ...
       ],
+    },
+  ],
+})
+```
+
+Or it can be an object that explicitly defines when user plugins will run, before or after the default ones.
+
+```js
+export default defineConfig({
+  entries: [
+    {
+      input: './src/index.ts',
+      output: './dist/index.mjs',
+      plugins: {
+        start: [plugin1()], // runs 'before' the default plugins
+        end: [plugin2()], // runs 'after' the default plugins
+      },
     },
   ],
 })

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -7,18 +7,29 @@ import type { Options as DtsOptions } from 'rollup-plugin-dts'
 
 type Externals = (string | RegExp)[]
 
-type ExportsExclude = {
+interface ExportsExclude {
   path: string
   types?: true
   import?: true
   require?: true
 }
 
-type ExportsMatcher = {
+interface ExportsMatcher {
   default?: string
   types?: string
   import?: string
   require?: string
+}
+
+interface PluginsOptions {
+  /**
+   * Runs `before` the default plugins.
+   */
+  start: Plugin[]
+  /**
+   * Runs `after` the default plugins.
+   */
+  end: Plugin[]
 }
 
 export interface Plugins {
@@ -37,7 +48,7 @@ export interface ExportsOptions extends Plugins {
   tsconfig?: string
   exclude?: (string | ExportsExclude)[]
   matcher?: ExportsMatcher
-  plugins?: Plugin[]
+  plugins?: Plugin[] | PluginsOptions
 }
 
 export interface BinOptions extends Omit<Plugins, 'dts'> {
@@ -48,7 +59,7 @@ export interface BinOptions extends Omit<Plugins, 'dts'> {
   tsconfig?: string
   exclude?: string[]
   matcher?: string
-  plugins?: Plugin[]
+  plugins?: Plugin[] | PluginsOptions
 }
 
 export interface EntriesOptions extends Plugins {
@@ -61,7 +72,7 @@ export interface EntriesOptions extends Plugins {
   footer?: OutputOptions['footer']
   minify?: boolean
   tsconfig?: string
-  plugins?: Plugin[]
+  plugins?: Plugin[] | PluginsOptions
 }
 
 export interface RolliOptions {


### PR DESCRIPTION

## Type of Change

- [x] New feature
- [x] Documentation


## Request Description

Extends the `plugins` option. 

### exports plugins


The `plugins` option accepts an array of plugins.

```js
export default defineConfig({
  exports: {
    plugins: [
      plugin1(),
      plugin2(),
      // ...
    ],
  },
})
```

Or it can be an object that explicitly defines when user plugins will run, before or after the default ones.

```js
export default defineConfig({
  exports: {
    plugins: {
      start: [plugin1()], // runs 'before' the default plugins
      end: [plugin2()], // runs 'after' the default plugins
    },
  },
})
```

### bin plugins


The `plugins` option accepts an array of plugins.

```js
export default defineConfig({
  bin: {
    plugins: [
      plugin1(),
      plugin2(),
      // ...
    ],
  },
})
```

Or it can be an object that explicitly defines when user plugins will run, before or after the default ones.

```js
export default defineConfig({
  bin: {
    plugins: {
      start: [plugin1()], // runs 'before' the default plugins
      end: [plugin2()], // runs 'after' the default plugins
    },
  },
})
```

### entries plugins


The `plugins` option accepts an array of plugins.

```js
export default defineConfig({
  entries: [
    {
      input: './src/index.ts',
      output: './dist/index.mjs',
      plugins: [
        plugin1(),
        plugin2(),
        // ...
      ],
    },
  ],
})
```

Or it can be an object that explicitly defines when user plugins will run, before or after the default ones.

```js
export default defineConfig({
  entries: [
    {
      input: './src/index.ts',
      output: './dist/index.mjs',
      plugins: {
        start: [plugin1()], // runs 'before' the default plugins
        end: [plugin2()], // runs 'after' the default plugins
      },
    },
  ],
})
```