### PR TITLE
feat: add new hooks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - Smart automatic bundler
 - Built-in ESM & TS support
 - Allows advanced customization
+- Provides a powerful hooking system
 - Exports fully optimized code
 - Auto-handles node hashbangs
 - Prints useful bundle stats
@@ -476,6 +477,35 @@ export default defineConfig({
 })
 ```
 
+### hooks
+
+- Type: `object`
+- Default: `undefined`
+
+Provides a powerful hooking system to further expand build modes.
+
+List of available [hooks](./src/types/hooks.ts):
+
+- `rolli:start`
+- `rolli:build:start`
+- `rolli:build:end`
+- `rolli:end`
+
+```js
+// rolli.config.js
+
+export default defineConfig({
+  hooks: {
+    'rolli:start': () => {
+      // ...
+    },
+    'rolli:end': async () => {
+      // ...
+    },
+  },
+})
+```
+
 ### minify
 
 - Type: `boolean`
@@ -504,7 +534,7 @@ npx rolli --minify
 
 Sets a custom TypeScript configuration for the entire bundle.
 
-By default, it uses the main _tsconfig.json_ file from the project's root.
+If not defined, it uses the main _tsconfig.json_ file from the project's root.
 
 ```js
 // rolli.config.js

--- a/src/cli/builder.ts
+++ b/src/cli/builder.ts
@@ -20,7 +20,7 @@ import {
   excludeBinPaths,
 } from '../utils/index.js'
 import type { InputOptions, ModuleFormat, Plugin } from 'rollup'
-import type { Plugins } from '../types/index.js'
+import type { Plugins } from '../types/plugins.js'
 import type {
   ConfigLoader,
   ArgsOptions,
@@ -89,6 +89,10 @@ export async function createBuilder(
 
   const outputLength = getLongestOutput(config)
   const typesExts = ['.d.ts', '.d.mts', '.d.cts']
+
+  if (config.hooks && config.hooks['rolli:build:start']) {
+    await config.hooks['rolli:build:start']()
+  }
 
   if (config.exportsPaths && config.exports !== false) {
     const exportsOptions = isObject(config.exports) ? config.exports : undefined
@@ -559,6 +563,10 @@ export async function createBuilder(
         outputLogs,
       )
     }
+  }
+
+  if (config.hooks && config.hooks['rolli:build:end']) {
+    await config.hooks['rolli:build:end']()
   }
 
   bundleStats.end = Date.now()

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,7 +22,15 @@ async function main() {
     return logger.printConfig(printConfig)
   }
 
+  if (config.hooks && config.hooks['rolli:start']) {
+    await config.hooks['rolli:start']()
+  }
+
   await createBuilder(rootDir, args, config).catch(error)
+
+  if (config.hooks && config.hooks['rolli:end']) {
+    await config.hooks['rolli:end']()
+  }
 }
 
 nodePatch()

--- a/src/types/bin.ts
+++ b/src/types/bin.ts
@@ -1,0 +1,13 @@
+import type { Plugin } from 'rollup'
+import type { Plugins, PluginsOptions } from './plugins.js'
+
+export interface BinOptions extends Omit<Plugins, 'dts'> {
+  srcDir?: string
+  externals?: (string | RegExp)[]
+  logFilter?: string[]
+  minify?: boolean
+  tsconfig?: string
+  exclude?: string[]
+  matcher?: string
+  plugins?: Plugin[] | PluginsOptions
+}

--- a/src/types/entries.ts
+++ b/src/types/entries.ts
@@ -1,0 +1,15 @@
+import type { OutputOptions, Plugin } from 'rollup'
+import type { Plugins, PluginsOptions } from './plugins.js'
+
+export interface EntriesOptions extends Plugins {
+  input: string
+  output: string
+  format?: OutputOptions['format']
+  externals?: (string | RegExp)[]
+  logFilter?: string[]
+  banner?: OutputOptions['banner']
+  footer?: OutputOptions['footer']
+  minify?: boolean
+  tsconfig?: string
+  plugins?: Plugin[] | PluginsOptions
+}

--- a/src/types/exports.ts
+++ b/src/types/exports.ts
@@ -1,0 +1,27 @@
+import type { Plugin } from 'rollup'
+import type { Plugins, PluginsOptions } from './plugins.js'
+
+export interface ExportsExclude {
+  path: string
+  types?: true
+  import?: true
+  require?: true
+}
+
+export interface ExportsMatcher {
+  default?: string
+  types?: string
+  import?: string
+  require?: string
+}
+
+export interface ExportsOptions extends Plugins {
+  srcDir?: string
+  externals?: (string | RegExp)[]
+  logFilter?: string[]
+  minify?: boolean
+  tsconfig?: string
+  exclude?: (string | ExportsExclude)[]
+  matcher?: ExportsMatcher
+  plugins?: Plugin[] | PluginsOptions
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,0 +1,6 @@
+export interface Hooks {
+  ['rolli:start']?: () => Promise<void>
+  ['rolli:build:start']?: () => Promise<void>
+  ['rolli:build:end']?: () => Promise<void>
+  ['rolli:end']?: () => Promise<void>
+}

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,99 +1,45 @@
-import type { OutputOptions, Plugin } from 'rollup'
-import type { RollupReplaceOptions } from '@rollup/plugin-replace'
-import type { RollupJsonOptions } from '@rollup/plugin-json'
-import type { RollupNodeResolveOptions } from '@rollup/plugin-node-resolve'
-import type { Options as EsbuildOptions } from 'rollup-plugin-esbuild'
-import type { Options as DtsOptions } from 'rollup-plugin-dts'
-
-type Externals = (string | RegExp)[]
-
-interface ExportsExclude {
-  path: string
-  types?: true
-  import?: true
-  require?: true
-}
-
-interface ExportsMatcher {
-  default?: string
-  types?: string
-  import?: string
-  require?: string
-}
-
-interface PluginsOptions {
-  /**
-   * Runs `before` the default plugins.
-   */
-  start: Plugin[]
-  /**
-   * Runs `after` the default plugins.
-   */
-  end: Plugin[]
-}
-
-export interface Plugins {
-  replace?: RollupReplaceOptions
-  json?: RollupJsonOptions | true
-  resolve?: RollupNodeResolveOptions | true
-  esbuild?: EsbuildOptions
-  dts?: DtsOptions
-}
-
-export interface ExportsOptions extends Plugins {
-  srcDir?: string
-  externals?: Externals
-  logFilter?: string[]
-  minify?: boolean
-  tsconfig?: string
-  exclude?: (string | ExportsExclude)[]
-  matcher?: ExportsMatcher
-  plugins?: Plugin[] | PluginsOptions
-}
-
-export interface BinOptions extends Omit<Plugins, 'dts'> {
-  srcDir?: string
-  externals?: Externals
-  logFilter?: string[]
-  minify?: boolean
-  tsconfig?: string
-  exclude?: string[]
-  matcher?: string
-  plugins?: Plugin[] | PluginsOptions
-}
-
-export interface EntriesOptions extends Plugins {
-  input: string
-  output: string
-  format?: OutputOptions['format']
-  externals?: Externals
-  logFilter?: string[]
-  banner?: OutputOptions['banner']
-  footer?: OutputOptions['footer']
-  minify?: boolean
-  tsconfig?: string
-  plugins?: Plugin[] | PluginsOptions
-}
+import type { ExportsOptions } from './exports.js'
+import type { BinOptions } from './bin.js'
+import type { EntriesOptions } from './entries.js'
+import type { Hooks } from './hooks.js'
 
 export interface RolliOptions {
   /**
-   * Auto-build `exports` mode.
+   * Defines the auto-build `exports` mode.
    *
    * @default enabled
    */
   exports?: ExportsOptions | false
   /**
-   * Auto-build `bin` mode.
+   * Defines the auto-build `bin` mode.
    *
    * @default enabled
    */
   bin?: BinOptions | false
   /**
-   * Custom-build `entries` mode.
+   * Defines the custom-build `entries` mode.
    *
    * @default undefined
    */
   entries?: EntriesOptions[]
+  /**
+   * Provides a powerful hooking system to further expand build modes.
+   *
+   * @default undefined
+   */
+  hooks?: Hooks
+  /**
+   * Minifies all bundle assets for production.
+   *
+   * @default undefined
+   */
   minify?: boolean
+  /**
+   * Sets a custom TypeScript configuration for the entire bundle.
+   *
+   * If not defined, it uses the main `tsconfig.json` file from the project's root.
+   *
+   * @default undefined
+   */
   tsconfig?: string
 }

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -1,0 +1,25 @@
+import type { Plugin } from 'rollup'
+import type { RollupReplaceOptions } from '@rollup/plugin-replace'
+import type { RollupJsonOptions } from '@rollup/plugin-json'
+import type { RollupNodeResolveOptions } from '@rollup/plugin-node-resolve'
+import type { Options as EsbuildOptions } from 'rollup-plugin-esbuild'
+import type { Options as DtsOptions } from 'rollup-plugin-dts'
+
+export interface PluginsOptions {
+  /**
+   * Runs `before` the default plugins.
+   */
+  start: Plugin[]
+  /**
+   * Runs `after` the default plugins.
+   */
+  end: Plugin[]
+}
+
+export interface Plugins {
+  replace?: RollupReplaceOptions
+  json?: RollupJsonOptions | true
+  resolve?: RollupNodeResolveOptions | true
+  esbuild?: EsbuildOptions
+  dts?: DtsOptions
+}

--- a/src/utils/excludePaths.ts
+++ b/src/utils/excludePaths.ts
@@ -1,5 +1,6 @@
 import { isString, isObject } from 'utills'
-import type { ExportsOptions, BinOptions } from '../types/options.js'
+import type { ExportsOptions } from '../types/exports.js'
+import type { BinOptions } from '../types/bin.js'
 import type { ConfigLoader } from '../types/cli/index.js'
 
 export function excludeExportsPaths(


### PR DESCRIPTION

## Type of Change

- [x] New feature
- [x] Documentation

## Request Description

Adds a new `hooks` option. 

Also, it reorganizes `types` dir structure.

### hooks

Provides a powerful hooking system to further expand build modes.

List of available hooks:

- `rolli:start`
- `rolli:build:start`
- `rolli:build:end`
- `rolli:end`

```js
// rolli.config.js

export default defineConfig({
  hooks: {
    'rolli:start': () => {
      // ...
    },
    'rolli:end': async () => {
      // ...
    },
  },
})
```
